### PR TITLE
Scaffold Android WebView wrapper app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,45 @@
+# Built application files
+*.apk
+*.aab
+*.ap_
+*.dex
+
+# Java/Kotlin/Android builds
+/out/
+build/
+app/build/
+*/build/
+
+# Gradle files
+.gradle/
+local.properties
+.gradle-local/
+
+# IntelliJ
+*.iml
+.idea/
+.idea/*
+!.idea/codeStyles/
+!.idea/codeStyles/*
+!.idea/runConfigurations/
+
+# Keystore files
+*.jks
+*.keystore
+
+# Android Studio Navigation editor temp files
+.navigation/
+
+# Google services (e.g. APIs or Firebase)
+app/google-services.json
+app/google-services.plist
+
+# Log Files
+*.log
+
+# Android Profiling
+captures/
+
+# Misc
+.DS_Store
+Thumbs.db

--- a/README.md
+++ b/README.md
@@ -1,0 +1,32 @@
+# HTML App Android Wrapper
+
+This project scaffolds a minimal Android application that wraps a WebView around the provided Flag Football tracker HTML experience. It mirrors the defaults from a fresh Android Studio Kotlin project and is ready for you to replace the bundled HTML or point the WebView at a remote site.
+
+## Getting started
+
+1. Install the latest [Android Studio](https://developer.android.com/studio) (Giraffe or newer) with the Android SDK platforms and tools for API level 34.
+2. Clone or copy this repository and open it from the **Open an Existing Project** option in Android Studio.
+3. When prompted, let Android Studio sync the Gradle project and download any missing dependencies.
+4. Connect an Android device or start an emulator running Android 7.0 (API 24) or later.
+5. Click **Run ▶** to build and launch the app.
+
+The Gradle wrapper is not included. To build from the command line, install Gradle 8.x locally and run:
+
+```bash
+gradle assembleDebug
+```
+
+## Swapping the bundled HTML
+
+* Replace `app/src/main/assets/index.html` with your own HTML file. The WebView automatically loads `file:///android_asset/index.html` on startup.
+* Add supporting assets (images, scripts, CSS) alongside `index.html` under `app/src/main/assets/` and reference them with relative URLs.
+
+## Loading a remote URL instead
+
+If you prefer to host the experience remotely:
+
+1. Open `app/src/main/java/com/example/htmlapp/MainActivity.kt`.
+2. Change the `ASSET_URL` constant to the desired URL (for example, `"https://example.com"`).
+3. Ensure the remote content is served over HTTPS or enable cleartext traffic for development via `app/src/debug/AndroidManifest.xml`.
+
+Rebuild and relaunch the application to verify that the WebView points at the remote content.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,0 +1,62 @@
+plugins {
+    id("com.android.application")
+    id("org.jetbrains.kotlin.android")
+}
+
+android {
+    namespace = "com.example.htmlapp"
+    compileSdk = 34
+
+    defaultConfig {
+        applicationId = "com.example.htmlapp"
+        minSdk = 24
+        targetSdk = 34
+        versionCode = 1
+        versionName = "1.0"
+
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+    }
+
+    buildTypes {
+        release {
+            isMinifyEnabled = false
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro"
+            )
+        }
+        debug {
+            isMinifyEnabled = false
+        }
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+    kotlinOptions {
+        jvmTarget = "17"
+    }
+
+    buildFeatures {
+        buildConfig = true
+    }
+
+    packaging {
+        resources {
+            excludes += "/META-INF/{AL2.0,LGPL2.1}"
+        }
+    }
+}
+
+dependencies {
+    implementation("androidx.core:core-ktx:1.12.0")
+    implementation("androidx.appcompat:appcompat:1.6.1")
+    implementation("com.google.android.material:material:1.11.0")
+    implementation("androidx.activity:activity-ktx:1.8.2")
+    implementation("androidx.webkit:webkit:1.9.0")
+
+    testImplementation("junit:junit:4.13.2")
+    androidTestImplementation("androidx.test.ext:junit:1.1.5")
+    androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
+}

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,0 +1,5 @@
+# Add project-specific ProGuard rules here.
+# You can control the set of applied configuration files using the
+# proguardFiles setting in build.gradle.kts.
+#
+# For more details, see https://developer.android.com/studio/build/shrink-code

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <application android:usesCleartextTraffic="true" />
+</manifest>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+
+    <application
+        android:allowBackup="true"
+        android:icon="@mipmap/ic_launcher"
+        android:label="@string/app_name"
+        android:networkSecurityConfig="@xml/network_security_config"
+        android:roundIcon="@mipmap/ic_launcher_round"
+        android:supportsRtl="true"
+        android:theme="@style/Theme.HtmlApp">
+        <!-- Uncomment the line below to permit cleartext HTTP traffic in release builds. -->
+        <!-- android:usesCleartextTraffic="true" -->
+
+        <activity
+            android:name=".MainActivity"
+            android:exported="true"
+            android:label="@string/app_name"
+            android:theme="@style/Theme.HtmlApp">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+
+</manifest>

--- a/app/src/main/assets/index.html
+++ b/app/src/main/assets/index.html
@@ -1,0 +1,446 @@
+<!-- Local HTML template loaded by WebView; replace its contents to customize the app. -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+  <title>Flag Football Tracker (Touch)</title>
+  <style>
+    :root {
+      --bg: #0f172a; /* slate-900 */
+      --card: #ffffff;
+      --ink: #0b1120;
+      --line: #e2e8f0;
+      --accent: #10b981; /* emerald-500 */
+      --danger: #ef4444;
+      --muted: #64748b;
+    }
+    html, body { height: 100%; }
+    body { margin: 0; overflow-x: hidden; background: var(--bg); color: #e5e7eb; font-family: system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif; }
+    .app { max-width: 900px; margin: 0 auto; padding: 8px 8px calc(180px + env(safe-area-inset-bottom)); }
+    h1 { font-size: 20px; margin: 10px 0 6px; font-weight: 800; }
+
+    /* Clock */
+    .clock { display:flex; align-items:center; justify-content:space-between; gap:8px; margin-bottom:8px; background:rgba(2,6,23,.7); border:1px solid rgba(148,163,184,.25); border-radius:14px; padding:8px 10px; }
+    .clock .left { display:flex; flex-direction:column; gap:4px; }
+    .clock .time { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size:26px; font-weight:900; cursor: pointer; }
+    .clock .controls { display:flex; gap:6px; flex-wrap: wrap; }
+    .clock .btn { padding:8px 10px; border-radius:12px; border:1px solid rgba(148,163,184,.35); background:#0f172a; color:#e5e7eb; font-weight:800; font-size:14px; }
+    .banner { font-size:12px; color:#cbd5e1; font-weight:800; letter-spacing:.02em; }
+
+    /* Teams: force two columns even on small screens (no side scrolling) */
+    .teams { display:grid; grid-template-columns: 1fr 1fr; gap: 8px; }
+
+    /* Team card */
+    .team { background: var(--card); color: var(--ink); border-radius: 14px; padding: 10px; box-shadow: 0 6px 18px rgba(0,0,0,.18); border: 2px solid var(--line); cursor: pointer; }
+    .team.active { border-color: var(--accent); box-shadow: 0 6px 18px rgba(16,185,129,.25); }
+    .team header { display:flex; align-items:center; justify-content:space-between; gap:6px; margin-bottom:6px; }
+    .name { font-weight: 900; font-size: 16px; user-select:none; padding:2px 4px; border-radius:6px; }
+    .name.editing { background:#f1f5f9; }
+    .name-input { font-weight:900; font-size:16px; width:100%; padding:4px 6px; border-radius:8px; border:2px solid var(--line); }
+
+    .stats { display:grid; grid-template-columns: 1fr 1fr; gap:6px; }
+    .stat { background:#f8fafc; border:1px solid var(--line); border-radius:10px; padding:6px; }
+    .stat.full { grid-column: 1 / -1; }
+    .stat label { display:block; font-size:11px; color:#334155; font-weight:700; margin-bottom:2px; }
+    .val { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 22px; font-weight: 900; cursor:pointer; }
+
+    /* Global control card */
+    .controls-card { position: fixed; left:0; right:0; bottom:0; padding: 8px 8px calc(8px + env(safe-area-inset-bottom)); background: rgba(2,6,23,.9); backdrop-filter: blur(10px); border-top: 1px solid rgba(148,163,184,.25); }
+    .controls { background:#0b1220; border:1px solid rgba(148,163,184,.35); border-radius:14px; padding:8px; }
+    .controls .label { font-size:12px; color:#94a3b8; font-weight:800; text-transform:uppercase; letter-spacing:.04em; margin-bottom:6px; }
+    .controls .row3 { display:grid; grid-template-columns:1fr 1fr 1fr; gap:6px; }
+    .controls .row2 { display:grid; grid-template-columns:1fr 1fr; gap:6px; margin-top:6px; }
+    .btn { -webkit-tap-highlight-color: transparent; display:inline-flex; align-items:center; justify-content:center; text-align:center; width:100%; padding:12px 8px; border-radius:12px; border:2px solid var(--line); font-weight:900; font-size:15px; background:#ffffff; }
+    .btn:active { transform: scale(0.98); }
+    .btn.primary { background: var(--accent); border-color: var(--accent); color:white; }
+    .btn.warn { background:#fee2e2; color:#7f1d1d; border-color:#fecaca; }
+
+    .muted { color: var(--muted); font-size:12px; }
+  </style>
+</head>
+<body>
+  <div class="app">
+    <h1>Flag Football Game Tracker</h1>
+
+    <!-- Game Clock -->
+    <div class="clock">
+      <div class="left">
+        <div class="muted">Game Clock</div>
+        <div class="banner" id="timeoutBanner" style="display:none;">Timeout — <span id="timeoutTeam"></span> <span id="timeoutTime">1:00</span></div>
+        <div class="banner" id="halftimeBanner" style="display:none;">Halftime — <span id="halftimeTime">2:00</span></div>
+      </div>
+      <div class="time" id="gameTime" title="Tap to edit when paused">15:00</div>
+      <div class="controls">
+        <button class="btn" id="clockStartPause">Start</button>
+        <button class="btn" id="timeoutHome">Timeout (Home)</button>
+        <button class="btn" id="timeoutAway">Timeout (Away)</button>
+        <button class="btn" id="halftimeBtn">Halftime</button>
+      </div>
+    </div>
+
+    <!-- Teams -->
+    <section class="teams" id="teams"></section>
+  </div>
+
+  <!-- Global Controls (shared by both teams) -->
+  <div class="controls-card">
+    <div class="controls">
+      <div class="label">Active team: <span id="activeTeamLabel">Home</span> — tap a team card to switch</div>
+      <div class="row3">
+        <button class="btn primary" id="g_score6">+6</button>
+        <button class="btn" id="g_score1">+1</button>
+        <button class="btn warn" id="g_scorem1">-1</button>
+      </div>
+      <!-- Reordered: First Down, Guy Play, Rush, Girl Play -->
+      <div class="row2">
+        <button class="btn" id="g_downReset">First Down</button>
+        <button class="btn" id="g_guyPlay">Guy Play</button>
+      </div>
+      <div class="row2">
+        <button class="btn" id="g_rushm1">Rush</button>
+        <button class="btn" id="g_girlPlay">Girl Play</button>
+      </div>
+    </div>
+  </div>
+
+<script>
+/**********************
+ * Storage & Migration
+ **********************/
+const STORAGE_KEY = 'flag_football_touch_v9';
+const LEGACY_KEYS = ['flag_football_touch_v8','flag_football_touch_v7','flag_football_touch_v6','flag_football_touch_v5','flag_football_touch_v4'];
+
+// NOTE: As of v9, girlPlay now represents "plays until required girl play" on a 0-2 scale
+// 2 -> "2", 1 -> "1", 0 -> "Now". Previously (v8 and earlier) girlPlay was 1..3 rolling counter.
+
+function serializeState(s){
+  return {
+    activeTeam: s.activeTeam,
+    teams: s.teams.map(t => ({
+      name: t.name,
+      score: t.score|0,
+      downs: Math.min(4, Math.max(1, t.downs|0)) || 1,
+      girlPlay: Math.min(2, Math.max(0, t.girlPlay|0)), // clamp to 0..2
+      rushes: Math.max(0, t.rushes|0),
+      timeouts: Math.max(0, t.timeouts|0)
+    })),
+    game: { seconds: Math.max(0, s.game?.seconds|0) || 15*60 }
+  };
+}
+
+function safeSave(){
+  const payload = JSON.stringify(serializeState(state));
+  try { localStorage.setItem(STORAGE_KEY, payload); }
+  catch(e){
+    try {
+      const tiny = JSON.stringify({
+        a: state.activeTeam,
+        t: state.teams.map(t=>({n:t.name, s:t.score|0, d:t.downs|0, g:Math.min(2,Math.max(0,t.girlPlay|0)), r:t.rushes|0, o:t.timeouts|0})),
+        g: {s: state.game.seconds|0}
+      });
+      localStorage.setItem(STORAGE_KEY, tiny);
+    } catch(e2){ try{ localStorage.removeItem(STORAGE_KEY);}catch{} }
+  }
+}
+let saveTimer=null; function scheduleSave(){ clearTimeout(saveTimer); saveTimer = setTimeout(safeSave, 400); }
+
+/**********************
+ * App State
+ **********************/
+const $ = (sel) => document.querySelector(sel);
+const $$ = (sel) => Array.from(document.querySelectorAll(sel));
+
+const defaultState = () => ({
+  activeTeam: 0,
+  teams: [
+    { name: 'Home', score: 0, downs: 1, girlPlay: 2, rushes: 2, timeouts: 3 }, // start at 2 plays until girl
+    { name: 'Away', score: 0, downs: 1, girlPlay: 2, rushes: 2, timeouts: 3 }
+  ],
+  game: { seconds: 15*60, running: false, timeoutSecondsRemaining: 0, timeoutTeam: null, halftimeSecondsRemaining: 0 }
+});
+
+function migrateGirlPlay(oldVal){
+  // v8 style (1..3 rolling) -> v9 remaining (2..0)
+  // Map: 1 -> 2, 2 -> 1, 3 -> 0
+  if (typeof oldVal !== 'number') return 2;
+  if (oldVal <= 1) return 2;
+  if (oldVal === 2) return 1;
+  return 0; // 3 or higher
+}
+
+function inflate(obj){
+  const base = defaultState(); if (!obj) return base;
+  try {
+    base.activeTeam = obj.activeTeam ?? obj.a ?? 0;
+    const teams = obj.teams ?? obj.t ?? base.teams;
+    base.teams = teams.map((t,i)=>{
+      const prev = base.teams[i] || {};
+      // Accept both schemas for girlPlay
+      const gp = (t.girlPlay == null) ? prev.girlPlay : t.girlPlay;
+      const girlV9 = (gp>=0 && gp<=2) ? gp : migrateGirlPlay(gp);
+      return {
+        name: t.name ?? t.n ?? prev.name ?? 'Team',
+        score: t.score ?? t.s ?? 0,
+        downs: t.downs ?? t.d ?? 1,
+        girlPlay: girlV9,
+        rushes: t.rushes ?? t.r ?? 2,
+        timeouts: t.timeouts ?? t.o ?? 3
+      };
+    });
+    const g = obj.game ?? obj.g ?? {};
+    base.game.seconds = g.seconds ?? g.s ?? 15*60;
+  } catch {}
+  return base;
+}
+
+function loadMigrated(){
+  try { const raw = localStorage.getItem(STORAGE_KEY); if (raw) return inflate(JSON.parse(raw)); } catch {}
+  for (const k of LEGACY_KEYS){
+    try {
+      const raw = localStorage.getItem(k); if (!raw) continue;
+      const migrated = inflate(JSON.parse(raw));
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(serializeState(migrated)));
+      try { localStorage.removeItem(k); } catch {}
+      return migrated;
+    } catch {}
+  }
+  return null;
+}
+
+let state = loadMigrated() || defaultState();
+let timeoutTimer = null; // 1:00 timeout
+let halftimeTimer = null; // 2:00 halftime
+let clockTimer = null;    // game clock
+
+/**********************
+ * Rendering
+ **********************/
+function fmt(sec){ const m=Math.floor(sec/60); const s=sec%60; return `${m}:${s.toString().padStart(2,'0')}`; }
+function fmtGirl(val){ return val===0 ? 'Now' : String(val); }
+
+function render(){
+  // Clock & banners
+  $('#gameTime').textContent = fmt(state.game.seconds);
+  if (state.game.timeoutSecondsRemaining>0){
+    $('#timeoutBanner').style.display='';
+    $('#timeoutTeam').textContent = state.teams[state.game.timeoutTeam]?.name || '';
+    $('#timeoutTime').textContent = fmt(state.game.timeoutSecondsRemaining);
+  } else { $('#timeoutBanner').style.display='none'; }
+  if (state.game.halftimeSecondsRemaining>0){
+    $('#halftimeBanner').style.display='';
+    $('#halftimeTime').textContent = fmt(state.game.halftimeSecondsRemaining);
+  } else { $('#halftimeBanner').style.display='none'; }
+
+  $('#clockStartPause').textContent = state.game.running ? 'Pause' : 'Start';
+  $('#activeTeamLabel').textContent = state.teams[state.activeTeam].name;
+  renderTeams();
+}
+
+function renderTeams(){
+  const host = $('#teams'); host.innerHTML = '';
+  state.teams.forEach((t, idx) => {
+    const sec = document.createElement('section'); sec.className = 'team' + (state.activeTeam===idx?' active':'');
+    sec.addEventListener('click', ()=>{ state.activeTeam = idx; render(); scheduleSave(); });
+
+    const header = document.createElement('header');
+    const nameSpan = document.createElement('span'); nameSpan.className = 'name'; nameSpan.textContent = t.name;
+    nameSpan.addEventListener('click', (ev)=>{ ev.stopPropagation(); beginEditName(idx, nameSpan); });
+    header.appendChild(nameSpan);
+
+    const stats = document.createElement('div'); stats.className = 'stats';
+    const score = document.createElement('div'); score.className = 'stat full'; score.innerHTML = `<label>Score</label><div class="val" data-kind="score" data-team="${idx}">${t.score}</div>`;
+    const down = document.createElement('div'); down.className='stat'; down.innerHTML = `<label>Down</label><div class="val" data-kind="downs" data-team="${idx}">${t.downs}</div>`;
+    const girl = document.createElement('div'); girl.className='stat'; girl.innerHTML = `<label>Girl Play In</label><div class="val" data-kind="girlPlay" data-team="${idx}">${fmtGirl(t.girlPlay)}</div>`;
+    const rush = document.createElement('div'); rush.className='stat'; rush.innerHTML = `<label>Rushes</label><div class="val" data-kind="rushes" data-team="${idx}">${t.rushes}</div>`;
+    const to = document.createElement('div'); to.className='stat'; to.innerHTML = `<label>Timeouts</label><div class="val" data-kind="timeouts" data-team="${idx}">${t.timeouts}</div>`;
+
+    [score,down,girl,rush,to].forEach(el=>stats.appendChild(el));
+
+    sec.appendChild(header); sec.appendChild(stats); host.appendChild(sec);
+  });
+
+  $$('.val').forEach(v => {
+    v.addEventListener('click', (ev)=>{ ev.stopPropagation(); beginEditValue(v.dataset.kind, +v.dataset.team); });
+  });
+}
+
+function beginEditName(idx, spanEl){
+  if (spanEl.classList.contains('editing')) return;
+  spanEl.classList.add('editing');
+  const input = document.createElement('input'); input.className = 'name-input'; input.value = state.teams[idx].name;
+  spanEl.replaceWith(input); input.focus(); input.setSelectionRange(0, input.value.length);
+  const finish = (commit) => {
+    const newSpan = document.createElement('span'); newSpan.className = 'name';
+    if (commit) state.teams[idx].name = input.value.trim() || state.teams[idx].name;
+    newSpan.textContent = state.teams[idx].name;
+    newSpan.addEventListener('click', (ev)=>{ ev.stopPropagation(); beginEditName(idx, newSpan); });
+    input.replaceWith(newSpan); render(); scheduleSave();
+  };
+  input.addEventListener('blur', () => finish(true));
+  input.addEventListener('keydown', (e)=>{ if(e.key==='Enter') finish(true); if(e.key==='Escape') finish(false); });
+}
+
+function beginEditValue(kind, teamIdx){
+  const t = state.teams[teamIdx];
+  const current = {score:t.score, downs:t.downs, girlPlay:t.girlPlay, rushes:t.rushes, timeouts:t.timeouts}[kind];
+  const hint = kind==='girlPlay' ? 'Enter 0-2 (0 = Now)' : (kind==='downs' ? 'Enter 1-4' : 'Enter a non-negative integer');
+  const input = prompt(`${kind} — ${hint}:`, String(current));
+  if (input==null) return;
+  const n = parseInt(String(input).trim(),10);
+  if (Number.isNaN(n)) return alert('Please enter a number');
+  if (kind==='downs'){ if (n<1||n>4) return alert('Down must be 1-4'); t.downs = n; }
+  else if (kind==='girlPlay'){ if (n<0||n>2) return alert('Girl Play In must be 0-2'); t.girlPlay = n; }
+  else if (kind==='score'){ t.score = Math.max(0, n); }
+  else if (kind==='rushes'){ t.rushes = Math.max(0, n); }
+  else if (kind==='timeouts'){ t.timeouts = Math.max(0, n); }
+  render(); scheduleSave();
+}
+
+/**********************
+ * Global Controls
+ **********************/
+$('#g_score6').addEventListener('click', ()=>{ state.teams[state.activeTeam].score += 6; render(); scheduleSave(); });
+$('#g_score1').addEventListener('click', ()=>{ state.teams[state.activeTeam].score += 1; render(); scheduleSave(); });
+$('#g_scorem1').addEventListener('click', ()=>{ state.teams[state.activeTeam].score = Math.max(0, state.teams[state.activeTeam].score - 1); render(); scheduleSave(); });
+
+// Guy/Girl play (v9 semantics)
+$('#g_guyPlay').addEventListener('click', ()=>{
+  const t = state.teams[state.activeTeam];
+  // +1 Down, decrement Girl Play In until 0 (Now), then stick at 0
+  t.downs = t.downs >= 4 ? 1 : t.downs + 1;
+  t.girlPlay = Math.max(0, (t.girlPlay|0) - 1);
+  render(); scheduleSave();
+});
+$('#g_girlPlay').addEventListener('click', ()=>{
+  const t = state.teams[state.activeTeam];
+  // Girl Play happens: reset counter to 2 and +1 Down
+  t.girlPlay = 2; 
+  t.downs = t.downs >= 4 ? 1 : t.downs + 1;
+  render(); scheduleSave();
+});
+
+// First Down
+$('#g_downReset').addEventListener('click', ()=>{ state.teams[state.activeTeam].downs = 1; render(); scheduleSave(); });
+
+// Rush (defense)
+$('#g_rushm1').addEventListener('click', ()=>{ const def = state.activeTeam===0?1:0; state.teams[def].rushes = Math.max(0, state.teams[def].rushes - 1); render(); scheduleSave(); });
+
+/**********************
+ * Clock, Timeout & Halftime
+ **********************/
+function clearTimeoutMode(){ if (timeoutTimer){ clearInterval(timeoutTimer); timeoutTimer=null; } state.game.timeoutSecondsRemaining=0; state.game.timeoutTeam=null; }
+function clearHalftimeMode(){ if (halftimeTimer){ clearInterval(halftimeTimer); halftimeTimer=null; } state.game.halftimeSecondsRemaining=0; }
+
+function startClock(){
+  if (state.game.timeoutSecondsRemaining>0) clearTimeoutMode();
+  if (state.game.halftimeSecondsRemaining>0) clearHalftimeMode();
+  if (clockTimer) return; state.game.running = true;
+  clockTimer = setInterval(()=>{ if (state.game.seconds>0){ state.game.seconds--; } else { pauseClock(); } render(); }, 1000);
+}
+function pauseClock(){ state.game.running=false; if (clockTimer){ clearInterval(clockTimer); clockTimer=null; } scheduleSave(); }
+function toggleStartPause(){ state.game.running ? pauseClock() : startClock(); render(); }
+
+function startTimeout(teamIdx){
+  if (timeoutTimer || state.game.timeoutSecondsRemaining>0) return; 
+  const t = state.teams[teamIdx]; if (t.timeouts<=0) return;
+  t.timeouts--; pauseClock(); clearHalftimeMode();
+  state.game.timeoutSecondsRemaining = 60; state.game.timeoutTeam = teamIdx;
+  timeoutTimer = setInterval(()=>{
+    if (state.game.timeoutSecondsRemaining>0){ state.game.timeoutSecondsRemaining--; render(); }
+    else { clearTimeoutMode(); render(); scheduleSave(); }
+  },1000);
+  render(); scheduleSave();
+}
+
+function startHalftime(){
+  pauseClock(); clearTimeoutMode();
+  state.teams.forEach(t=>{ t.downs=1; t.girlPlay=2; t.rushes=2; t.timeouts=3; });
+  state.game.seconds = 15*60;
+  state.game.halftimeSecondsRemaining = 120;
+  if (halftimeTimer) clearInterval(halftimeTimer);
+  halftimeTimer = setInterval(()=>{
+    if (state.game.halftimeSecondsRemaining>0){ state.game.halftimeSecondsRemaining--; render(); }
+    else { clearHalftimeMode(); render(); scheduleSave(); }
+  }, 1000);
+  render(); scheduleSave();
+}
+
+$('#clockStartPause').addEventListener('click', toggleStartPause);
+$('#timeoutHome').addEventListener('click', ()=> startTimeout(0));
+$('#timeoutAway').addEventListener('click', ()=> startTimeout(1));
+$('#halftimeBtn').addEventListener('click', startHalftime);
+
+// Edit time when paused
+$('#gameTime').addEventListener('click', ()=>{
+  if (state.game.running || state.game.timeoutSecondsRemaining>0 || state.game.halftimeSecondsRemaining>0) return;
+  const current = fmt(state.game.seconds);
+  const input = prompt('Set game clock (MM:SS):', current);
+  if (!input) return;
+  const m = input.match(/^(\d{1,2}):(\d{2})$/);
+  if (!m) return alert('Please enter time as MM:SS');
+  const mm = parseInt(m[1],10), ss = parseInt(m[2],10);
+  if (ss>59) return alert('Seconds must be 00-59');
+  state.game.seconds = Math.max(0, mm*60 + ss);
+  render(); scheduleSave();
+});
+
+/**********************
+ * Init
+ **********************/
+render();
+
+/**********************
+ * Self-tests (run with #test)
+ **********************/
+(function devTests(){
+  if (location.hash !== '#test') return; console.group('[Self Tests]');
+  try {
+    const size = JSON.stringify(serializeState(state)).length; console.log('Persist size (bytes):', size); console.assert(size < 100000, 'payload <100KB');
+
+    // Debounced writes
+    let writes = 0; const _setItem = localStorage.setItem.bind(localStorage); localStorage.setItem = (k,v)=>{ if(k===STORAGE_KEY) writes++; _setItem(k,v); };
+    for (let i=0;i<20;i++){ state.teams[0].score++; scheduleSave(); }
+    setTimeout(()=>{ console.log('Debounced writes (<=5 expected):', writes); localStorage.setItem = _setItem; }, 1200);
+
+    // Timeout -> Start behavior
+    startTimeout(0);
+    setTimeout(()=>{
+      console.assert(state.game.timeoutSecondsRemaining>0, 'timeout should be running');
+      toggleStartPause();
+      console.assert(state.game.timeoutSecondsRemaining===0, 'timeout cleared on Start');
+      console.assert(state.game.running===true, 'game clock should be running after Start');
+      pauseClock();
+
+      // Rush affects defense
+      state.activeTeam = 0; const beforeDef = state.teams[1].rushes; document.getElementById('g_rushm1').click();
+      console.assert(state.teams[1].rushes === Math.max(0, beforeDef-1), 'Rush decrements defending');
+
+      // v9 Girl Play semantics
+      state.activeTeam = 0; state.teams[0].girlPlay = 2; state.teams[0].downs = 1; // reset
+      document.getElementById('g_guyPlay').click(); // expect 1
+      console.assert(state.teams[0].girlPlay === 1, 'Guy Play decrements to 1');
+      document.getElementById('g_guyPlay').click(); // expect 0
+      console.assert(state.teams[0].girlPlay === 0, 'Guy Play decrements to 0 (Now)');
+      document.getElementById('g_guyPlay').click(); // stays 0
+      console.assert(state.teams[0].girlPlay === 0, 'Guy Play stays at 0');
+      document.getElementById('g_girlPlay').click(); // reset to 2
+      console.assert(state.teams[0].girlPlay === 2, 'Girl Play button resets to 2');
+
+      // Halftime resets girl counter to 2
+      startHalftime();
+      console.assert(state.teams.every(t=> t.girlPlay===2), 'Halftime sets Girl Play In to 2');
+      toggleStartPause(); console.assert(state.game.halftimeSecondsRemaining===0, 'halftime cleared on Start'); pauseClock();
+
+      // Editable girl counter
+      const savedPrompt = window.prompt; window.prompt = ()=> '0';
+      beginEditValue('girlPlay',0); console.assert(state.teams[0].girlPlay===0, 'edit Girl Play In to 0');
+      window.prompt = savedPrompt;
+
+      console.groupEnd();
+    }, 150);
+  } catch (e) { console.warn('Self tests error:', e); console.groupEnd(); }
+})();
+</script>
+</body>
+</html>

--- a/app/src/main/java/com/example/htmlapp/MainActivity.kt
+++ b/app/src/main/java/com/example/htmlapp/MainActivity.kt
@@ -1,0 +1,206 @@
+package com.example.htmlapp
+
+import android.annotation.SuppressLint
+import android.content.ActivityNotFoundException
+import android.content.Intent
+import android.net.Uri
+import android.os.Bundle
+import android.view.View
+import android.webkit.CookieManager
+import android.webkit.ValueCallback
+import android.webkit.WebChromeClient
+import android.webkit.WebResourceRequest
+import android.webkit.WebSettings
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import android.widget.ProgressBar
+import android.widget.Toast
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.isVisible
+import com.example.htmlapp.BuildConfig
+
+private const val ASSET_URL = "file:///android_asset/index.html"
+
+class MainActivity : AppCompatActivity() {
+
+    private lateinit var webView: WebView
+    private lateinit var progressBar: ProgressBar
+
+    private var filePathCallback: ValueCallback<Array<Uri>>? = null
+    private lateinit var fileChooserLauncher: ActivityResultLauncher<Intent>
+
+    @SuppressLint("SetJavaScriptEnabled")
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_main)
+
+        progressBar = findViewById(R.id.progressBar)
+        webView = findViewById(R.id.webView)
+
+        setupFileChooser()
+        configureWebView()
+
+        if (savedInstanceState != null) {
+            webView.restoreState(savedInstanceState)
+        } else {
+            webView.loadUrl(ASSET_URL)
+        }
+
+        WebView.setWebContentsDebuggingEnabled(BuildConfig.DEBUG)
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        webView.saveState(outState)
+    }
+
+    override fun onDestroy() {
+        webView.apply {
+            loadUrl("about:blank")
+            stopLoading()
+            clearHistory()
+            removeAllViews()
+            destroy()
+        }
+        super.onDestroy()
+    }
+
+    override fun onBackPressed() {
+        if (webView.canGoBack()) {
+            webView.goBack()
+        } else {
+            super.onBackPressed()
+        }
+    }
+
+    private fun setupFileChooser() {
+        fileChooserLauncher = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
+            val callback = filePathCallback
+            val data = result.data
+            if (callback == null) {
+                return@registerForActivityResult
+            }
+
+            val uris: Array<Uri>? = if (result.resultCode == RESULT_OK) {
+                when {
+                    data == null -> null
+                    data.clipData != null -> {
+                        val clipData = data.clipData
+                        if (clipData != null) {
+                            Array(clipData.itemCount) { index -> clipData.getItemAt(index).uri }
+                        } else {
+                            null
+                        }
+                    }
+                    data.data != null -> arrayOf(data.data!!)
+                    else -> null
+                }
+            } else {
+                null
+            }
+
+            callback.onReceiveValue(uris)
+            filePathCallback = null
+        }
+    }
+
+    @SuppressLint("SetJavaScriptEnabled")
+    private fun configureWebView() {
+        with(webView.settings) {
+            javaScriptEnabled = true
+            domStorageEnabled = true
+            allowFileAccess = true
+            allowContentAccess = true
+            mixedContentMode = WebSettings.MIXED_CONTENT_COMPATIBILITY_MODE
+            loadWithOverviewMode = true
+            useWideViewPort = true
+            builtInZoomControls = false
+            displayZoomControls = false
+        }
+
+        CookieManager.getInstance().setAcceptCookie(true)
+
+        webView.scrollBarStyle = View.SCROLLBARS_INSIDE_OVERLAY
+
+        webView.webViewClient = object : WebViewClient() {
+            override fun shouldOverrideUrlLoading(view: WebView?, request: WebResourceRequest?): Boolean {
+                val uri = request?.url ?: return false
+                return handleExternalUri(uri)
+            }
+
+            @Deprecated("Deprecated in Java")
+            override fun shouldOverrideUrlLoading(view: WebView?, url: String?): Boolean {
+                return url?.let { handleExternalUri(Uri.parse(it)) } ?: false
+            }
+        }
+
+        webView.webChromeClient = object : WebChromeClient() {
+            override fun onProgressChanged(view: WebView?, newProgress: Int) {
+                progressBar.isVisible = newProgress < 100
+                progressBar.progress = newProgress
+            }
+
+            override fun onShowFileChooser(
+                webView: WebView?,
+                filePathCallback: ValueCallback<Array<Uri>>?,
+                fileChooserParams: FileChooserParams
+            ): Boolean {
+                this@MainActivity.filePathCallback?.onReceiveValue(null)
+                this@MainActivity.filePathCallback = filePathCallback
+
+                val intent = try {
+                    fileChooserParams.createIntent()
+                } catch (e: Exception) {
+                    Intent(Intent.ACTION_OPEN_DOCUMENT).apply {
+                        addCategory(Intent.CATEGORY_OPENABLE)
+                        type = "*/*"
+                        putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true)
+                    }
+                }
+
+                return if (intent.resolveActivity(packageManager) != null) {
+                    try {
+                        fileChooserLauncher.launch(intent)
+                        true
+                    } catch (e: ActivityNotFoundException) {
+                        showToast(R.string.webview_no_file_picker)
+                        this@MainActivity.filePathCallback?.onReceiveValue(null)
+                        this@MainActivity.filePathCallback = null
+                        false
+                    }
+                } else {
+                    showToast(R.string.webview_no_file_picker)
+                    this@MainActivity.filePathCallback?.onReceiveValue(null)
+                    this@MainActivity.filePathCallback = null
+                    false
+                }
+            }
+        }
+    }
+
+    private fun handleExternalUri(uri: Uri): Boolean {
+        val scheme = uri.scheme ?: return false
+        return when (scheme.lowercase()) {
+            "http", "https", "mailto", "tel" -> {
+                openExternalLink(uri)
+                true
+            }
+            else -> false
+        }
+    }
+
+    private fun openExternalLink(uri: Uri) {
+        val intent = Intent(Intent.ACTION_VIEW, uri)
+        try {
+            startActivity(intent)
+        } catch (ex: ActivityNotFoundException) {
+            showToast(R.string.webview_unable_to_open_link)
+        }
+    }
+
+    private fun showToast(messageRes: Int) {
+        Toast.makeText(this, messageRes, Toast.LENGTH_SHORT).show()
+    }
+}

--- a/app/src/main/res/drawable/ic_launcher_background.xml
+++ b/app/src/main/res/drawable/ic_launcher_background.xml
@@ -1,0 +1,3 @@
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
+    <solid android:color="@color/ic_launcher_background" />
+</shape>

--- a/app/src/main/res/drawable/ic_launcher_foreground.xml
+++ b/app/src/main/res/drawable/ic_launcher_foreground.xml
@@ -1,0 +1,22 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:fillAlpha="0.9"
+        android:pathData="M24,24h60v60h-60z" />
+    <path
+        android:fillColor="#311B92"
+        android:pathData="M30,36h48v6H30z" />
+    <path
+        android:fillColor="#311B92"
+        android:pathData="M30,48h48v6H30z" />
+    <path
+        android:fillColor="#311B92"
+        android:pathData="M30,60h32v6H30z" />
+    <path
+        android:fillColor="#311B92"
+        android:pathData="M30,72h26v6H30z" />
+</vector>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:fitsSystemWindows="true">
+
+    <ProgressBar
+        android:id="@+id/progressBar"
+        style="?android:attr/progressBarStyleHorizontal"
+        android:layout_width="match_parent"
+        android:layout_height="4dp"
+        android:layout_gravity="top"
+        android:indeterminate="false"
+        android:max="100"
+        android:progress="0"
+        android:visibility="gone" />
+
+    <WebView
+        android:id="@+id/webView"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:overScrollMode="never"
+        android:scrollbarStyle="outsideOverlay" />
+
+</LinearLayout>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -1,0 +1,4 @@
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@drawable/ic_launcher_background" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground" />
+</adaptive-icon>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -1,0 +1,4 @@
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@drawable/ic_launcher_background" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground" />
+</adaptive-icon>

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -1,0 +1,11 @@
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <style name="Theme.HtmlApp" parent="Theme.Material3.DayNight.NoActionBar">
+        <item name="android:statusBarColor" tools:targetApi="l">@android:color/transparent</item>
+        <item name="android:navigationBarColor">@android:color/transparent</item>
+        <item name="android:windowLightStatusBar" tools:targetApi="m">false</item>
+        <item name="android:windowLightNavigationBar" tools:targetApi="o_mr1">false</item>
+        <item name="android:forceDarkAllowed" tools:targetApi="q">false</item>
+        <item name="windowNoTitle">true</item>
+        <item name="windowActionBar">false</item>
+    </style>
+</resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,0 +1,30 @@
+<resources>
+    <color name="md_theme_light_primary">#6750A4</color>
+    <color name="md_theme_light_onPrimary">#FFFFFF</color>
+    <color name="md_theme_light_primaryContainer">#EADDFF</color>
+    <color name="md_theme_light_onPrimaryContainer">#21005D</color>
+    <color name="md_theme_light_secondary">#625B71</color>
+    <color name="md_theme_light_onSecondary">#FFFFFF</color>
+    <color name="md_theme_light_secondaryContainer">#E8DEF8</color>
+    <color name="md_theme_light_onSecondaryContainer">#1D192B</color>
+    <color name="md_theme_light_background">#FFFBFE</color>
+    <color name="md_theme_light_onBackground">#1C1B1F</color>
+    <color name="md_theme_light_surface">#FFFBFE</color>
+    <color name="md_theme_light_onSurface">#1C1B1F</color>
+
+    <color name="md_theme_dark_primary">#D0BCFF</color>
+    <color name="md_theme_dark_onPrimary">#381E72</color>
+    <color name="md_theme_dark_primaryContainer">#4F378B</color>
+    <color name="md_theme_dark_onPrimaryContainer">#EADDFF</color>
+    <color name="md_theme_dark_secondary">#CCC2DC</color>
+    <color name="md_theme_dark_onSecondary">#332D41</color>
+    <color name="md_theme_dark_secondaryContainer">#4A4458</color>
+    <color name="md_theme_dark_onSecondaryContainer">#E8DEF8</color>
+    <color name="md_theme_dark_background">#1C1B1F</color>
+    <color name="md_theme_dark_onBackground">#E6E1E5</color>
+    <color name="md_theme_dark_surface">#1C1B1F</color>
+    <color name="md_theme_dark_onSurface">#E6E1E5</color>
+
+    <color name="seed">#6750A4</color>
+    <color name="ic_launcher_background">#6750A4</color>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,0 +1,5 @@
+<resources>
+    <string name="app_name">HTML App</string>
+    <string name="webview_unable_to_open_link">No application can open this link.</string>
+    <string name="webview_no_file_picker">No app available to select files.</string>
+</resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,0 +1,11 @@
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <style name="Theme.HtmlApp" parent="Theme.Material3.DayNight.NoActionBar">
+        <item name="android:statusBarColor" tools:targetApi="l">@android:color/transparent</item>
+        <item name="android:navigationBarColor">@android:color/transparent</item>
+        <item name="android:windowLightStatusBar" tools:targetApi="m">false</item>
+        <item name="android:windowLightNavigationBar" tools:targetApi="o_mr1">false</item>
+        <item name="android:forceDarkAllowed" tools:targetApi="q">false</item>
+        <item name="windowNoTitle">true</item>
+        <item name="windowActionBar">false</item>
+    </style>
+</resources>

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <base-config cleartextTrafficPermitted="false">
+        <trust-anchors>
+            <certificates src="system" />
+        </trust-anchors>
+    </base-config>
+    <debug-overrides>
+        <trust-anchors>
+            <certificates src="system" />
+            <certificates src="user" />
+        </trust-anchors>
+    </debug-overrides>
+</network-security-config>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,0 +1,4 @@
+plugins {
+    id("com.android.application") version "8.2.2" apply false
+    id("org.jetbrains.kotlin.android") version "1.9.22" apply false
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,0 +1,18 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+rootProject.name = "FlagFootbal"
+include(":app")


### PR DESCRIPTION
## Summary
- add top-level Gradle configuration and Android-focused gitignore mirroring a fresh Android Studio Kotlin project
- scaffold an `app` module with Material 3 resources, manifests, local HTML asset, and network security configuration
- implement `MainActivity` and layout to host the bundled WebView experience with navigation, progress, external link, and file chooser support, plus usage documentation

## Testing
- Not run (Gradle wrapper not provided in repository)

------
https://chatgpt.com/codex/tasks/task_b_68cb1142d86c832b96ced3f50a688026