### PR TITLE
Rework scoreboard layout and preserve editing

### DIFF
--- a/app/src/main/assets/index.html
+++ b/app/src/main/assets/index.html
@@ -17,32 +17,35 @@
     }
     html, body { height: 100%; }
     body { margin: 0; overflow-x: hidden; background: var(--bg); color: #e5e7eb; font-family: system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif; }
-    .app { max-width: 900px; margin: 0 auto; padding: 8px 8px calc(240px + env(safe-area-inset-bottom)); }
-    h1 { font-size: 20px; margin: 10px 0 6px; font-weight: 800; }
+    .app { max-width: 1040px; margin: 0 auto; padding: 16px 12px 32px; display:flex; flex-direction:column; gap:16px; min-height:100vh; }
+    h1 { font-size: 20px; margin: 10px 0 6px; font-weight: 800; text-align:center; }
+
+    .layout { display:flex; align-items:flex-start; gap:16px; }
+    .primary { flex:1; min-width:0; display:flex; flex-direction:column; gap:12px; }
 
     /* Clock */
-    .clock { display:flex; align-items:center; justify-content:space-between; gap:8px; margin-bottom:8px; background:rgba(2,6,23,.7); border:1px solid rgba(148,163,184,.25); border-radius:14px; padding:8px 10px; }
+    .clock { display:flex; align-items:center; justify-content:space-between; gap:8px; background:rgba(2,6,23,.7); border:1px solid rgba(148,163,184,.25); border-radius:14px; padding:8px 10px; }
     .clock .left { display:flex; flex-direction:column; gap:4px; }
     .clock .time { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size:26px; font-weight:900; cursor: pointer; }
-    .clock .controls { display:flex; gap:6px; flex-wrap: wrap; }
-    .clock .btn { padding:8px 10px; border-radius:12px; border:1px solid rgba(148,163,184,.35); background:#0f172a; color:#e5e7eb; font-weight:800; font-size:14px; }
+    .clock-controls { display:flex; gap:6px; flex-wrap: wrap; justify-content:flex-end; }
+    .clock-controls .btn { padding:8px 10px; border-radius:12px; border:1px solid rgba(148,163,184,.35); background:#0f172a; color:#e5e7eb; font-weight:800; font-size:14px; }
     .banner { font-size:12px; color:#cbd5e1; font-weight:800; letter-spacing:.02em; }
 
-    /* Teams: force two columns even on small screens (no side scrolling) */
-    .teams { display:grid; grid-template-columns: 1fr 1fr; gap: 8px; }
+    /* Teams */
+    .teams { display:grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 12px; }
 
     /* Team card */
     .team { background: var(--card); color: var(--ink); border-radius: 14px; padding: 10px; box-shadow: 0 6px 18px rgba(0,0,0,.18); border: 2px solid var(--line); cursor: pointer; }
     .team.active { border-color: var(--accent); box-shadow: 0 6px 18px rgba(16,185,129,.25); }
-    .team header { display:flex; align-items:center; justify-content:space-between; gap:6px; margin-bottom:6px; }
+    .team header { display:flex; align-items:center; justify-content:center; gap:6px; margin-bottom:10px; }
     .name { font-weight: 900; font-size: 16px; user-select:none; padding:2px 4px; border-radius:6px; }
     .name.editing { background:#f1f5f9; }
-    .name-input { font-weight:900; font-size:16px; width:100%; padding:4px 6px; border-radius:8px; border:2px solid var(--line); }
+    .name-input { font-weight:900; font-size:16px; width:100%; padding:4px 6px; border-radius:8px; border:2px solid var(--line); text-align:center; }
 
-    .stats { display:grid; grid-template-columns: 1fr 1fr; gap:6px; }
-    .stat { background:#f8fafc; border:1px solid var(--line); border-radius:10px; padding:6px; }
+    .stats { display:grid; grid-template-columns: 1fr 1fr; gap:10px; }
+    .stat { background:#f8fafc; border:1px solid var(--line); border-radius:10px; padding:10px; display:flex; flex-direction:column; align-items:center; gap:6px; text-align:center; }
     .stat.full { grid-column: 1 / -1; }
-    .stat label { display:block; font-size:11px; color:#334155; font-weight:700; margin-bottom:2px; }
+    .stat label { display:block; font-size:11px; color:#334155; font-weight:700; text-transform:uppercase; letter-spacing:.04em; }
 
     /* Inline numeric editor (kept from codex/refactor-inline-editor...) */
     .val { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 22px; font-weight: 900; cursor:pointer; text-align:center; }
@@ -54,62 +57,73 @@
     .val-error.visible { visibility:visible; }
 
     /* Global control card */
-    .controls-card { position: fixed; left:0; right:0; bottom:0; padding: 8px 8px calc(8px + env(safe-area-inset-bottom)); background: rgba(2,6,23,.9); backdrop-filter: blur(10px); border-top: 1px solid rgba(148,163,184,.25); }
-    .controls { background:#0b1220; border:1px solid rgba(148,163,184,.35); border-radius:14px; padding:8px; }
+    .controls-card { position:sticky; top:120px; width: min(280px, 45vw); align-self:stretch; flex-shrink:0; }
+    .controls { background:#0b1220; border:1px solid rgba(148,163,184,.35); border-radius:14px; padding:12px; display:flex; flex-direction:column; gap:10px; max-height: calc(100vh - 160px); overflow:auto; }
     .controls .label { font-size:12px; color:#94a3b8; font-weight:800; text-transform:uppercase; letter-spacing:.04em; margin-bottom:6px; }
-    .controls .row3 { display:grid; grid-template-columns:1fr 1fr 1fr; gap:6px; }
-    .controls .row2 { display:grid; grid-template-columns:1fr 1fr; gap:6px; margin-top:6px; }
-    .btn { -webkit-tap-highlight-color: transparent; display:inline-flex; align-items:center; justify-content:center; text-align:center; width:100%; padding:12px 8px; border-radius:12px; border:2px solid var(--line); font-weight:900; font-size:15px; background:#ffffff; }
+    .controls .row3 { display:grid; grid-template-columns:repeat(3, 1fr); gap:8px; }
+    .controls .row2 { display:grid; grid-template-columns:repeat(2, 1fr); gap:8px; }
+    .btn { -webkit-tap-highlight-color: transparent; display:inline-flex; align-items:center; justify-content:center; text-align:center; width:100%; padding:12px 10px; border-radius:12px; border:2px solid var(--line); font-weight:900; font-size:15px; background:#ffffff; }
     .btn.tall { padding-top: 24px; padding-bottom: 24px; }
     .btn:active { transform: scale(0.98); }
     .btn.primary { background: var(--accent); border-color: var(--accent); color:white; }
     .btn.warn { background:#fee2e2; color:#7f1d1d; border-color:#fecaca; }
 
     .muted { color: var(--muted); font-size:12px; }
+
+    @media (max-width: 860px) {
+      .layout { flex-direction:column; }
+      .controls-card { position:static; width:100%; }
+      .controls { flex-direction:column; max-height:none; overflow:visible; }
+      .teams { grid-template-columns:repeat(auto-fit, minmax(160px, 1fr)); }
+    }
   </style>
 </head>
 <body>
   <div class="app">
     <h1>Flag Football Game Tracker</h1>
 
-    <!-- Game Clock -->
-    <div class="clock">
-      <div class="left">
-        <div class="muted">Game Clock</div>
-        <div class="banner" id="timeoutBanner" style="display:none;">Timeout — <span id="timeoutTeam"></span> <span id="timeoutTime">1:00</span></div>
-        <div class="banner" id="halftimeBanner" style="display:none;">Halftime — <span id="halftimeTime">2:00</span></div>
-      </div>
-      <div class="time" id="gameTime" title="Tap to edit when paused">15:00</div>
-      <div class="controls">
-        <button class="btn" id="clockStartPause">Start</button>
-        <button class="btn" id="timeoutHome">Timeout (Home)</button>
-        <button class="btn" id="timeoutAway">Timeout (Away)</button>
-        <button class="btn" id="halftimeBtn">Halftime</button>
-      </div>
-    </div>
+    <div class="layout">
+      <div class="primary">
+        <!-- Game Clock -->
+        <div class="clock">
+          <div class="left">
+            <div class="muted">Game Clock</div>
+            <div class="banner" id="timeoutBanner" style="display:none;">Timeout — <span id="timeoutTeam"></span> <span id="timeoutTime">1:00</span></div>
+            <div class="banner" id="halftimeBanner" style="display:none;">Halftime — <span id="halftimeTime">2:00</span></div>
+          </div>
+          <div class="time" id="gameTime" title="Tap to edit when paused">15:00</div>
+          <div class="clock-controls">
+            <button class="btn" id="clockStartPause">Start</button>
+            <button class="btn" id="timeoutHome">Timeout (Home)</button>
+            <button class="btn" id="timeoutAway">Timeout (Away)</button>
+            <button class="btn" id="halftimeBtn">Halftime</button>
+          </div>
+        </div>
 
-    <!-- Teams -->
-    <section class="teams" id="teams"></section>
-  </div>
+        <!-- Teams -->
+        <section class="teams" id="teams"></section>
+      </div>
 
-  <!-- Global Controls (shared by both teams) -->
-  <div class="controls-card">
-    <div class="controls">
-      <div class="label">Active team: <span id="activeTeamLabel">Home</span> — tap a team card to switch</div>
-      <div class="row3">
-        <button class="btn primary" id="g_score6">+6</button>
-        <button class="btn" id="g_score1">+1</button>
-        <button class="btn warn" id="g_scorem1">-1</button>
-      </div>
-      <!-- Reordered: First Down, Guy Play, Rush, Girl Play -->
-      <div class="row2">
-        <button class="btn tall" id="g_downReset">First Down</button>
-        <button class="btn tall" id="g_guyPlay">Guy Play</button>
-      </div>
-      <div class="row2">
-        <button class="btn tall" id="g_rushm1">Rush</button>
-        <button class="btn tall" id="g_girlPlay">Girl Play</button>
-      </div>
+      <!-- Global Controls (shared by both teams) -->
+      <aside class="controls-card">
+        <div class="controls">
+          <div class="label">Active team: <span id="activeTeamLabel">Home</span> — tap a team card to switch</div>
+          <div class="row3">
+            <button class="btn primary" id="g_score6">+6</button>
+            <button class="btn" id="g_score1">+1</button>
+            <button class="btn warn" id="g_scorem1">-1</button>
+          </div>
+          <!-- Reordered: First Down, Guy Play, Rush, Girl Play -->
+          <div class="row2">
+            <button class="btn tall" id="g_downReset">First Down</button>
+            <button class="btn tall" id="g_guyPlay">Guy Play</button>
+          </div>
+          <div class="row2">
+            <button class="btn tall" id="g_rushm1">Rush</button>
+            <button class="btn tall" id="g_girlPlay">Girl Play</button>
+          </div>
+        </div>
+      </aside>
     </div>
   </div>
 
@@ -256,6 +270,22 @@ function render(){
 }
 
 function renderTeams(){
+  const editingVal = document.querySelector('.val.editing');
+  let restoreEdit = null;
+  if (editingVal) {
+    const { team, kind } = editingVal.dataset;
+    const input = editingVal.querySelector('input');
+    if (team != null && kind && input) {
+      restoreEdit = {
+        team: Number(team),
+        kind,
+        value: input.value,
+        selectionStart: input.selectionStart ?? input.value.length,
+        selectionEnd: input.selectionEnd ?? input.value.length
+      };
+    }
+  }
+
   activeValueEditor = null;
   const host = $('#teams'); host.innerHTML = '';
   state.teams.forEach((t, idx) => {
@@ -282,6 +312,13 @@ function renderTeams(){
   $$('.val').forEach(v => {
     v.addEventListener('click', (ev)=>{ ev.stopPropagation(); beginEditValue(v, v.dataset.kind, +v.dataset.team); });
   });
+
+  if (restoreEdit) {
+    const valEl = host.querySelector(`.val[data-team="${restoreEdit.team}"][data-kind="${restoreEdit.kind}"]`);
+    if (valEl) {
+      beginEditValue(valEl, restoreEdit.kind, restoreEdit.team, { skipCancelExisting: true, restore: restoreEdit });
+    }
+  }
 }
 
 function beginEditName(idx, spanEl){
@@ -300,16 +337,17 @@ function beginEditName(idx, spanEl){
   input.addEventListener('keydown', (e)=>{ if(e.key==='Enter') finish(true); if(e.key==='Escape') finish(false); });
 }
 
-function beginEditValue(valEl, kind, teamIdx){
+function beginEditValue(valEl, kind, teamIdx, opts = {}){
   if (!valEl || valEl.classList.contains('editing')) return;
   const team = state.teams[teamIdx];
   const rules = VALUE_RULES[kind];
   if (!team || !rules) return;
 
-  if (activeValueEditor) activeValueEditor(false);
+  if (activeValueEditor && !opts.skipCancelExisting) activeValueEditor(false);
 
   const originalDisplay = kind==='girlPlay' ? fmtGirl(team.girlPlay) : String(team[kind] ?? '');
   const originalValue = String(team[kind] ?? '');
+  const startingValue = opts.restore?.value ?? originalValue;
 
   valEl.classList.add('editing');
   valEl.textContent = '';
@@ -321,7 +359,7 @@ function beginEditValue(valEl, kind, teamIdx){
   input.pattern = '[0-9]*';
   input.autocomplete = 'off';
   input.spellcheck = false;
-  input.value = originalValue;
+  input.value = startingValue;
   input.setAttribute('aria-label', `${rules.label} for ${team.name}`);
   valEl.appendChild(input);
 
@@ -334,7 +372,16 @@ function beginEditValue(valEl, kind, teamIdx){
   error.setAttribute('aria-live','polite');
   valEl.appendChild(error);
 
-  const focusInput = () => { input.focus(); if (typeof input.select === 'function') input.select(); };
+  const focusInput = () => {
+    input.focus();
+    if (opts.restore && opts.restore.selectionStart != null) {
+      const end = opts.restore.selectionEnd ?? opts.restore.selectionStart;
+      try { input.setSelectionRange(opts.restore.selectionStart, end); }
+      catch {}
+    } else if (typeof input.select === 'function') {
+      input.select();
+    }
+  };
   const showError = (msg) => {
     error.textContent = msg || '';
     error.classList.toggle('visible', !!msg);
@@ -379,6 +426,7 @@ function beginEditValue(valEl, kind, teamIdx){
   });
   input.addEventListener('blur', ()=>{
     setTimeout(()=>{
+      if (!valEl.isConnected) return;
       const active = document.activeElement;
       if (!valEl.contains(active)) finish(true);
     }, 20);


### PR DESCRIPTION
## Summary
- center the title and stat tiles while moving the control panel into a right-aligned sidebar
- keep inline stat editors active while the clock continues to run by restoring the active editor on re-render
- tweak responsive styles so the new layout adapts on smaller viewports

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68d828dbffa4832bae2dfb3240374dee