### PR TITLE
Pause WebView when app backgrounded

### DIFF
--- a/app/src/main/java/com/example/htmlapp/MainActivity.kt
+++ b/app/src/main/java/com/example/htmlapp/MainActivity.kt
@@ -67,6 +67,22 @@ class MainActivity : AppCompatActivity() {
         super.onDestroy()
     }
 
+    override fun onPause() {
+        webView.apply {
+            onPause()
+            pauseTimers()
+        }
+        super.onPause()
+    }
+
+    override fun onResume() {
+        webView.apply {
+            onResume()
+            resumeTimers()
+        }
+        super.onResume()
+    }
+
     override fun onBackPressed() {
         if (webView.canGoBack()) {
             webView.goBack()


### PR DESCRIPTION
## Summary
- override `onPause` and `onResume` in `MainActivity`
- pause and resume the embedded WebView (including timers) to keep the game clock in sync with app visibility

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68d83aba338c832b99b1db7d1565a287