### PR TITLE
Use WebViewAssetLoader for local assets

### DIFF
--- a/app/src/main/java/com/example/htmlapp/MainActivity.kt
+++ b/app/src/main/java/com/example/htmlapp/MainActivity.kt
@@ -10,6 +10,7 @@ import android.webkit.CookieManager
 import android.webkit.ValueCallback
 import android.webkit.WebChromeClient
 import android.webkit.WebResourceRequest
+import android.webkit.WebResourceResponse
 import android.webkit.WebSettings
 import android.webkit.WebView
 import android.webkit.WebViewClient
@@ -19,14 +20,23 @@ import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.isVisible
+import androidx.webkit.WebViewAssetLoader
 import com.example.htmlapp.BuildConfig
 
-private const val ASSET_URL = "file:///android_asset/index.html"
+private const val ASSET_URL = "https://appassets.androidplatform.net/assets/index.html"
 
 class MainActivity : AppCompatActivity() {
 
     private lateinit var webView: WebView
     private lateinit var progressBar: ProgressBar
+
+    private val assetLoader by lazy {
+        WebViewAssetLoader.Builder()
+            .addPathHandler("/assets/", WebViewAssetLoader.AssetsPathHandler(this))
+            .build()
+    }
+
+    private val assetHost: String? = Uri.parse(ASSET_URL).host
 
     private var filePathCallback: ValueCallback<Array<Uri>>? = null
     private lateinit var fileChooserLauncher: ActivityResultLauncher<Intent>
@@ -111,8 +121,8 @@ class MainActivity : AppCompatActivity() {
         with(webView.settings) {
             javaScriptEnabled = true
             domStorageEnabled = true
-            allowFileAccess = true
-            allowContentAccess = true
+            allowFileAccess = false
+            allowContentAccess = false
             mixedContentMode = WebSettings.MIXED_CONTENT_COMPATIBILITY_MODE
             loadWithOverviewMode = true
             useWideViewPort = true
@@ -127,12 +137,34 @@ class MainActivity : AppCompatActivity() {
         webView.webViewClient = object : WebViewClient() {
             override fun shouldOverrideUrlLoading(view: WebView?, request: WebResourceRequest?): Boolean {
                 val uri = request?.url ?: return false
+                if (uri.host?.equals(assetHost, ignoreCase = true) == true) {
+                    return false
+                }
                 return handleExternalUri(uri)
             }
 
             @Deprecated("Deprecated in Java")
             override fun shouldOverrideUrlLoading(view: WebView?, url: String?): Boolean {
-                return url?.let { handleExternalUri(Uri.parse(it)) } ?: false
+                return url?.let {
+                    val uri = Uri.parse(it)
+                    if (uri.host?.equals(assetHost, ignoreCase = true) == true) {
+                        false
+                    } else {
+                        handleExternalUri(uri)
+                    }
+                } ?: false
+            }
+
+            override fun shouldInterceptRequest(
+                view: WebView?,
+                request: WebResourceRequest?
+            ): WebResourceResponse? {
+                return assetLoader.shouldInterceptRequest(request?.url)
+            }
+
+            @Deprecated("Deprecated in Java")
+            override fun shouldInterceptRequest(view: WebView?, url: String?): WebResourceResponse? {
+                return assetLoader.shouldInterceptRequest(url?.let(Uri::parse))
             }
         }
 


### PR DESCRIPTION
## Summary
- switch the WebView to load bundled files via WebViewAssetLoader
- disable direct file/content access and intercept asset requests through the loader
- ensure only external hosts trigger the external URL handler while internal navigation stays in-app

## Testing
- `bash ./gradlew lint` *(fails: Unable to download Gradle distribution because the proxy returned HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_b_68d83ab851cc832b9aca4862690bb821