### PR TITLE
Avoid padStart in WebView index

### DIFF
--- a/app/src/main/assets/index.html
+++ b/app/src/main/assets/index.html
@@ -533,7 +533,7 @@ const remoteSync = {
 /**********************
  * Rendering
  **********************/
-function fmt(sec){ const m=Math.floor(sec/60); const s=sec%60; return `${m}:${s.toString().padStart(2,'0')}`; }
+function fmt(sec){ const m=Math.floor(sec/60); const s=sec%60; const padded = ('0' + s).slice(-2); return `${m}:${padded}`; }
 function fmtGirl(val){ return val===0 ? 'Now' : String(val); }
 
 function render(){


### PR DESCRIPTION
## Summary
- replace the padStart helper in the clock formatter with manual zero padding to keep compatibility with older WebView runtimes

## Testing
- not run (environment does not include an API 24 WebView/emulator)


------
https://chatgpt.com/codex/tasks/task_b_68d84ac9b814832ba5771c74d212d59c