### PR TITLE
Add league field to profile data and UI

### DIFF
--- a/app/src/main/assets/index.html
+++ b/app/src/main/assets/index.html
@@ -229,6 +229,7 @@
             <div class="profile-card__details">
               <div class="profile-card__name" id="profileFirstName">Name</div>
               <div class="profile-card__team" id="profileTeamName">Team</div>
+              <div class="profile-card__league" id="profileLeagueName">League</div>
               <div class="profile-card__location" id="profileLocation">City, Province</div>
             </div>
           </div>
@@ -301,6 +302,22 @@
                 aria-labelledby="profileTeamLabel profileTeamValue"
               >
                 <span class="profile-form__field-value is-placeholder" id="profileTeamValue" data-profile-field-value="teamName">Team</span>
+                <span class="profile-form__field-chevron" aria-hidden="true"></span>
+              </button>
+            </div>
+
+            <div class="profile-form__group">
+              <span class="profile-form__label sr-only" id="profileLeagueLabel">League</span>
+              <button
+                class="profile-form__field-button"
+                type="button"
+                data-profile-field="league"
+                data-profile-field-title="League"
+                data-profile-field-name="league"
+                data-profile-field-placeholder="League"
+                aria-labelledby="profileLeagueLabel profileLeagueValue"
+              >
+                <span class="profile-form__field-value is-placeholder" id="profileLeagueValue" data-profile-field-value="league">League</span>
                 <span class="profile-form__field-chevron" aria-hidden="true"></span>
               </button>
             </div>

--- a/app/src/main/assets/scripts/modules/state.js
+++ b/app/src/main/assets/scripts/modules/state.js
@@ -32,6 +32,7 @@
       teamName: '',
       city: '',
       province: '',
+      league: '',
       photoData: null
     };
   }
@@ -81,6 +82,7 @@
     base.teamName = coerceProfileString(profile.teamName != null ? profile.teamName : (profile.team != null ? profile.team : profile.tn));
     base.city = coerceProfileString(profile.city != null ? profile.city : profile.c);
     base.province = coerceProfileString(profile.province != null ? profile.province : (profile.provinceCode != null ? profile.provinceCode : profile.pv));
+    base.league = coerceProfileString(profile.league != null ? profile.league : (profile.leagueId != null ? profile.leagueId : (profile.teamLeague != null ? profile.teamLeague : profile.lg)));
     let photo = profile.photoData != null ? profile.photoData : (profile.photo != null ? profile.photo : (profile.image != null ? profile.image : profile.i));
     if (typeof photo === 'string') {
       const trimmed = photo.trim();
@@ -306,6 +308,7 @@
         if (profile.teamName) profilePayload.tn = profile.teamName;
         if (profile.city) profilePayload.c = profile.city;
         if (profile.province) profilePayload.pv = profile.province;
+        if (profile.league) profilePayload.lg = profile.league;
         if (profile.photoData) profilePayload.ph = profile.photoData;
         const tinyObj = {
           a: state.activeTeam,

--- a/app/src/main/assets/scripts/modules/ui.js
+++ b/app/src/main/assets/scripts/modules/ui.js
@@ -329,6 +329,12 @@
       if (nameEl) nameEl.textContent = firstName;
       const teamEl = exports.$('#profileTeamName');
       if (teamEl) teamEl.textContent = teamName;
+      const leagueEl = exports.$('#profileLeagueName');
+      if (leagueEl) {
+        const leagueText = profile.league && profile.league.trim() ? profile.league.trim() : 'League';
+        leagueEl.textContent = leagueText;
+        leagueEl.classList.toggle('is-placeholder', !profile.league || !profile.league.trim());
+      }
       const locationEl = exports.$('#profileLocation');
       if (locationEl) {
         const parts = [];
@@ -362,6 +368,7 @@
       setField('#profileTeamValue',      profile.teamName,  'Team');
       setField('#profileCityValue',      profile.city,      'City');
       setField('#profileProvinceValue',  profile.province,  'Province');
+      setField('#profileLeagueValue',    profile.league,    'League');
       // ✅ End of new block
 
       const accessibleLabel = firstName && firstName !== 'Name'

--- a/app/src/main/assets/scripts/triggers.js
+++ b/app/src/main/assets/scripts/triggers.js
@@ -72,7 +72,7 @@ window.triggerGirlPlay = function () {
   // Helper: seed the big Edit Profile sheet preview spans from state
   function seedProfileEditorFromState(){
     const p = (window.App?.state?.profile) || {};
-    const placeholders = { firstName: 'Name', teamName: 'Team', city: 'City', province: 'Province' };
+    const placeholders = { firstName: 'Name', teamName: 'Team', city: 'City', province: 'Province', league: 'League' };
 
     const setPreview = (k, val) => {
       const el = document.querySelector(`[data-profile-field-value="${k}"]`);
@@ -86,6 +86,7 @@ window.triggerGirlPlay = function () {
     setPreview('teamName',  p.teamName);
     setPreview('city',      p.city);
     setPreview('province',  p.province);
+    setPreview('league',    p.league);
   }
 
   // Helper: swap text input -> <select> populated from Firebase Teams
@@ -180,7 +181,7 @@ window.triggerGirlPlay = function () {
     if (fieldSheet) fieldSheet.dataset.key = fieldKey;
 
     // Get current preview text from big editor (not from state)
-    const placeholders = { firstName: 'Name', teamName: 'Team', city: 'City', province: 'Province' };
+    const placeholders = { firstName: 'Name', teamName: 'Team', city: 'City', province: 'Province', league: 'League' };
     const previewEl = document.querySelector(`[data-profile-field-value="${fieldKey}"]`);
     const previewTextRaw = (previewEl?.textContent || '').trim();
     const previewText = previewTextRaw && previewTextRaw !== placeholders[fieldKey] ? previewTextRaw : '';
@@ -286,7 +287,7 @@ window.triggerGirlPlay = function () {
       // Update the visible value in the big Edit Profile sheet
       const preview = document.querySelector(`[data-profile-field-value="${key}"]`);
       if (preview) {
-        const placeholders = { firstName: 'Name', teamName: 'Team', city: 'City', province: 'Province' };
+        const placeholders = { firstName: 'Name', teamName: 'Team', city: 'City', province: 'Province', league: 'League' };
         preview.textContent = next || placeholders[key] || '';
         preview.classList.toggle('is-placeholder', !next);
       }
@@ -308,8 +309,8 @@ window.triggerGirlPlay = function () {
     profileForm.addEventListener('submit', (e) => {
       e.preventDefault();
 
-      const placeholders = { firstName: 'Name', teamName: 'Team', city: 'City', province: 'Province' };
-      const keys = ['firstName', 'teamName', 'city', 'province'];
+      const placeholders = { firstName: 'Name', teamName: 'Team', city: 'City', province: 'Province', league: 'League' };
+      const keys = ['firstName', 'teamName', 'city', 'province', 'league'];
       const app = window.App || {};
       const nextProfile = {};
 
@@ -369,6 +370,7 @@ window.triggerGirlPlay = function () {
           normalizedProfile.teamName = safeString(profile?.teamName);
           normalizedProfile.city = safeString(profile?.city);
           normalizedProfile.province = safeProvince(profile?.province);
+          normalizedProfile.league = safeString(profile?.league);
           if (normalizedProfile.photoData == null) {
             normalizedProfile.photoData = null;
           }


### PR DESCRIPTION
## Summary
- extend the stored profile model to keep a sanitized league value and persist it in storage fallbacks
- add a league field to the profile card and editor so users can view and edit it alongside other profile details
- ensure the profile form flow and remote sync include the league entry when saving

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691768c90e44832bb02e56e7cd1df8e3)