### PR TITLE
Flatten Firebase user profile structure

### DIFF
--- a/app/src/main/assets/scripts/triggers.js
+++ b/app/src/main/assets/scripts/triggers.js
@@ -378,11 +378,14 @@ window.triggerGirlPlay = function () {
           const payload = {
             uid: normalizedUid,
             name: normalizedProfile.firstName,
+            firstName: normalizedProfile.firstName,
             team: normalizedProfile.teamName,
+            teamName: normalizedProfile.teamName,
             city: normalizedProfile.city,
             province: normalizedProfile.province,
             league: safeLeague(),
-            profile: normalizedProfile
+            photoData: normalizedProfile.photoData,
+            profile: null
           };
 
           return payload;


### PR DESCRIPTION
## Summary
- update the profile form sync payload so user details are stored directly on the Firebase user node
- include top-level duplicates of first name, team name, and photo data while clearing the legacy nested profile object

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69179540ed54832b9ba3fd93f9e518cc)