### PR TITLE
Handle league value when hydrating profile data

### DIFF
--- a/app/src/main/assets/scripts/modules/state.js
+++ b/app/src/main/assets/scripts/modules/state.js
@@ -439,17 +439,18 @@
         return payload.profile;
       }
 
-      if (hasAnyKeys(payload, ['name', 'team', 'city', 'province'])) {
+      if (hasAnyKeys(payload, ['name', 'team', 'city', 'province', 'league'])) {
         return {
           firstName: payload.name,
           teamName: payload.team,
           city: payload.city,
           province: payload.province,
+          league: payload.league ?? payload.leagueName ?? payload.teamLeague,
           photoData: payload.photoData ?? payload.photo ?? payload.image ?? payload.i ?? null
         };
       }
 
-      if (hasAnyKeys(payload, ['firstName', 'teamName', 'city', 'province', 'photoData', 'fn', 'tn', 'c', 'pv', 'photo', 'image', 'i'])) {
+      if (hasAnyKeys(payload, ['firstName', 'teamName', 'city', 'province', 'league', 'photoData', 'fn', 'tn', 'c', 'pv', 'lg', 'photo', 'image', 'i'])) {
         return payload;
       }
     }


### PR DESCRIPTION
## Summary
- include the league key when normalizing realtime profile payloads
- forward the league value pulled from /users/<uid>/league into the app state
- allow payloads with legacy league keys (leagueName, teamLeague) to hydrate correctly

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6917a671364c832b9f654c144f688914)