### PR TITLE
Add configurable timing controls for game and intermission

### DIFF
--- a/app/src/main/assets/index.html
+++ b/app/src/main/assets/index.html
@@ -43,6 +43,19 @@
       <div class="sync-status" id="syncStatus" role="status">Offline</div>
 
     </div>
+    <div class="drawer-section">
+      <h2>Timing</h2>
+      <form id="timingSettingsForm" novalidate>
+        <label for="segmentLengthInput">Segment Length (minutes)</label>
+        <input id="segmentLengthInput" name="segmentLength" type="number" step="0.1" min="0.1" inputmode="decimal" autocomplete="off" aria-describedby="timingSettingsNote" placeholder="25" />
+
+        <label for="intermissionLengthInput">Intermission Length (minutes)</label>
+        <input id="intermissionLengthInput" name="intermissionLength" type="number" step="0.1" min="0.1" inputmode="decimal" autocomplete="off" aria-describedby="timingSettingsNote" placeholder="5" />
+      </form>
+      <p class="drawer-note" id="timingSettingsNote">
+        These values determine the default countdowns for each game segment and intermission.
+      </p>
+    </div>
   </nav>
   <div class="drawer-backdrop" id="menuBackdrop" tabindex="-1" aria-hidden="true"></div>
 

--- a/app/src/main/assets/scripts/modules/ui.js
+++ b/app/src/main/assets/scripts/modules/ui.js
@@ -457,6 +457,10 @@
     document.body.dataset.view = exports.viewMode;
     const isFlagged = !!exports.state.flagged;
     document.body.classList.toggle('flagged', isFlagged);
+    if (typeof exports.syncTimingInputs === 'function') {
+      try { exports.syncTimingInputs(); }
+      catch (err) { console.warn('[ui] timing sync failed', err); }
+    }
     if (typeof exports.renderTeamStatsGrid === 'function') {
       try { exports.renderTeamStatsGrid(); }
       catch (err) { console.warn('[ui] team stats render failed', err); }


### PR DESCRIPTION
## Summary
- add timing controls to the side drawer so segment and intermission lengths can be edited
- persist the timing settings in local and remote state and expose helpers to access them
- update halftime/reset logic and UI rendering to respect the configurable timings

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6917d688a70c832b9fcfcf97dc2f6551)