### PR TITLE
Add intermission control to timing menu

### DIFF
--- a/app/src/main/assets/index.html
+++ b/app/src/main/assets/index.html
@@ -52,6 +52,7 @@
         <label for="intermissionLengthInput">Intermission Length (minutes)</label>
         <input id="intermissionLengthInput" name="intermissionLength" type="number" step="0.1" min="0.1" inputmode="decimal" autocomplete="off" aria-describedby="timingSettingsNote" placeholder="5" />
       </form>
+      <button class="secondary" type="button" id="intermissionBtn" data-role="ref-only">Intermission</button>
       <p class="drawer-note" id="timingSettingsNote">
         These values determine the default countdowns for each game segment and intermission.
       </p>

--- a/app/src/main/assets/scripts/modules/controls.js
+++ b/app/src/main/assets/scripts/modules/controls.js
@@ -587,7 +587,7 @@
     }
   }
 
-  function startHalftime(){
+  function startIntermission(){
     if (exports.viewMode !== 'ref') return;
     const now = Date.now();
     exports.reconcileAll(now);
@@ -639,6 +639,10 @@
         s.halftime.running = true;
       });
     }
+  }
+
+  function startHalftime(){
+    startIntermission();
   }
 
   function openMenu(){
@@ -1140,6 +1144,14 @@
       signOutBtn.addEventListener('click', () => {
         try { closeMenu(); } catch {}
         performSignOut();
+      });
+    }
+
+    const intermissionBtn = exports.$ ? exports.$('#intermissionBtn') : null;
+    if (intermissionBtn) {
+      intermissionBtn.addEventListener('click', () => {
+        startIntermission();
+        try { closeMenu(); } catch {}
       });
     }
   }
@@ -2257,6 +2269,7 @@ if (typeof exports.initializeControls === 'function') {
   exports.pauseClock = pauseClock;
   exports.toggleStartPause = toggleStartPause;
   exports.startTimeout = startTimeout;
+  exports.startIntermission = startIntermission;
   exports.startHalftime = startHalftime;
   exports.openMenu = openMenu;
   exports.closeMenu = closeMenu;


### PR DESCRIPTION
## Summary
- add an Intermission button to the timing drawer so referees can trigger an intermission from the side menu
- reuse the halftime workflow via a new `startIntermission` helper that resets clocks, timers, and team counters
- wire the menu control to the intermission logic and export it for other modules

## Testing
- not run (web assets)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6917db2713cc832ba6a5a25986755845)