### PR TITLE
Add intermission countdown display on game clock

### DIFF
--- a/app/src/main/assets/index.html
+++ b/app/src/main/assets/index.html
@@ -69,6 +69,7 @@
             <section class="team-card" id="teamCard0"></section>
 
             <div class="clock-card">
+              <div class="banner" id="intermissionBanner" style="display:none;">Intermission <span id="intermissionTime">5:00</span></div>
               <div class="banner" id="timeoutBanner" style="display:none;">Timeout — <span id="timeoutTeam"></span> <span id="timeoutTime">1:00</span></div>
               <div class="clock-tiles">
                 <div class="clock-tile">

--- a/app/src/main/assets/scripts/modules/ui.js
+++ b/app/src/main/assets/scripts/modules/ui.js
@@ -541,6 +541,15 @@
           if (timeoutTime) timeoutTime.textContent = fmt(timeoutSeconds);
         } else { timeoutBanner.style.display='none'; }
       }
+      const intermissionSeconds = exports.state.halftime?.secondsRemaining || 0;
+      const intermissionBanner = exports.$('#intermissionBanner');
+      if (intermissionBanner) {
+        if (intermissionSeconds > 0 && timeoutSeconds <= 0){
+          intermissionBanner.style.display='';
+          const intermissionTime = exports.$('#intermissionTime');
+          if (intermissionTime) intermissionTime.textContent = fmt(intermissionSeconds);
+        } else { intermissionBanner.style.display='none'; }
+      }
     }
 
     const startPauseBtn = exports.$ ? exports.$('#clockStartPause') : null;


### PR DESCRIPTION
## Summary
- add an intermission banner to the game clock so intermission countdowns are visible on the scoreboard
- update the UI renderer to drive the banner from the halftime countdown state

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6917e1e0b4dc832b95adc7e0f2522fbf)