### PR TITLE
Prevent keyboard from repositioning profile editor

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,7 +18,8 @@
             android:name=".MainActivity"
             android:exported="true"
             android:label="@string/app_name"
-            android:theme="@style/Theme.Synqro">
+            android:theme="@style/Theme.Synqro"
+            android:windowSoftInputMode="stateUnchanged|adjustNothing">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />


### PR DESCRIPTION
## Summary
- ensure MainActivity keeps its layout stable when the soft keyboard opens by setting windowSoftInputMode to adjustNothing

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6917fce948dc832bbb38a997b07b0ef7)