### PR TITLE
Adjust profile field sheet for keyboard

### DIFF
--- a/app/src/main/assets/styles/app.css
+++ b/app/src/main/assets/styles/app.css
@@ -881,6 +881,7 @@
       align-items: flex-end;
       pointer-events: none;
       transition: opacity 0.3s ease;
+      padding-bottom: var(--keyboard-inset, 0px);
     }
 
     .profile-field-sheet[aria-hidden="true"] {


### PR DESCRIPTION
## Summary
- add keyboard inset padding to the profile field sheet container so it shifts up with the on-screen keyboard

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6917ff780578832b9c8d69ccc6aeadc1)