### PR TITLE
Ensure profile field sheet stays above keyboard

### DIFF
--- a/app/src/main/assets/styles/app.css
+++ b/app/src/main/assets/styles/app.css
@@ -913,7 +913,7 @@
       padding: 24px clamp(20px, 8vw, 32px) calc(24px + var(--keyboard-inset, 0px));
       padding-bottom: calc(24px + var(--keyboard-inset, 0px) + env(safe-area-inset-bottom));
       box-shadow: 0 16px 42px rgba(15, 23, 42, 0.28);
-      transform: translateY(100%);
+      transform: translateY(calc(100% + var(--keyboard-inset, 0px)));
       transition: transform 0.32s ease;
       display: flex;
       flex-direction: column;
@@ -921,7 +921,7 @@
     }
 
     .profile-field-sheet[data-open="true"] .profile-field-sheet__panel {
-      transform: translateY(0%);
+      transform: translateY(calc(0px - var(--keyboard-inset, 0px)));
     }
 
     .profile-field-sheet__header {


### PR DESCRIPTION
## Summary
- adjust the profile field sheet panel transform to respect the runtime keyboard inset
- allow the panel to shift upward when the virtual keyboard is shown so it remains visible

## Testing
- Not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6918044b88e0832b83c6031366521e34)