### PR TITLE
Add ProfileEditorActivity and navigation button

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -26,6 +26,13 @@
             </intent-filter>
         </activity>
 
+        <activity
+            android:name=".ProfileEditorActivity"
+            android:exported="false"
+            android:label="@string/app_name"
+            android:theme="@style/Theme.Synqro"
+            android:windowSoftInputMode="stateUnchanged|adjustNothing" />
+
         <receiver
             android:name=".ScoreboardWidgetProvider"
             android:exported="false">

--- a/app/src/main/java/com/synqro/app/MainActivity.kt
+++ b/app/src/main/java/com/synqro/app/MainActivity.kt
@@ -69,6 +69,7 @@ class MainActivity : AppCompatActivity() {
     private lateinit var loginEmailInput: TextInputEditText
     private lateinit var loginProgress: CircularProgressIndicator
     private lateinit var loginStatus: TextView
+    private lateinit var profileEditorButton: MaterialButton
     private lateinit var backCallback: OnBackPressedCallback
 
     private val assetLoader by lazy {
@@ -113,6 +114,7 @@ class MainActivity : AppCompatActivity() {
         loginEmailInput = findViewById(R.id.loginEmailInput)
         loginProgress = findViewById(R.id.loginProgress)
         loginStatus = findViewById(R.id.loginStatus)
+        profileEditorButton = findViewById(R.id.profileEditorButton)
 
         loginEmailInput.doAfterTextChanged {
             if (loginEmailLayout.isErrorEnabled) {
@@ -135,6 +137,10 @@ class MainActivity : AppCompatActivity() {
 
         signInButton.setOnClickListener {
             launchSignIn()
+        }
+
+        profileEditorButton.setOnClickListener {
+            startActivity(Intent(this, ProfileEditorActivity::class.java))
         }
 
         // FIX: create an OnBackPressedCallback object and register it

--- a/app/src/main/java/com/synqro/app/ProfileEditorActivity.kt
+++ b/app/src/main/java/com/synqro/app/ProfileEditorActivity.kt
@@ -1,0 +1,12 @@
+package com.synqro.app
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+
+class ProfileEditorActivity : AppCompatActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_profile_editor)
+    }
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -201,6 +201,21 @@
                 android:textColor="@color/login_text_muted"
                 android:textSize="12sp" />
 
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/profileEditorButton"
+                style="@style/Widget.MaterialComponents.Button"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="24dp"
+                android:insetTop="14dp"
+                android:insetBottom="14dp"
+                android:text="@string/open_profile_editor"
+                android:textAllCaps="false"
+                android:textSize="16sp"
+                app:backgroundTint="@color/login_field_background"
+                app:cornerRadius="16dp"
+                android:textColor="@color/login_text_primary" />
+
         </LinearLayout>
     </ScrollView>
 

--- a/app/src/main/res/layout/activity_profile_editor.xml
+++ b/app/src/main/res/layout/activity_profile_editor.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/login_background"
+    android:padding="24dp">
+
+    <LinearLayout
+        android:id="@+id/profileEditor"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:gravity="center_horizontal">
+
+        <TextView
+            android:id="@+id/profileEditorTitle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="16dp"
+            android:text="@string/profile_editor_title"
+            android:textColor="@color/login_text_primary"
+            android:textSize="24sp"
+            android:textStyle="bold" />
+
+        <TextView
+            android:id="@+id/profileEditorDescription"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="24dp"
+            android:gravity="center"
+            android:text="@string/profile_editor_description"
+            android:textColor="@color/login_text_secondary"
+            android:textSize="16sp" />
+
+    </LinearLayout>
+
+</ScrollView>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -29,4 +29,7 @@
     <string name="login_sign_out_error">Unable to sign out right now. Please try again.</string>
     <string name="widget_title">Open Synqro</string>
     <string name="widget_content_description">Launch Synqro</string>
+    <string name="profile_editor_title">Profile editor</string>
+    <string name="profile_editor_description">Update your account details in this dedicated editor.</string>
+    <string name="open_profile_editor">Open profile editor</string>
 </resources>


### PR DESCRIPTION
## Summary
- add a dedicated ProfileEditorActivity that inflates the activity_profile_editor layout
- move the profile editor UI into its own layout resource and reference it from the new activity
- wire MainActivity and the manifest to launch the profile editor from a new button

## Testing
- ./gradlew lint *(fails: SDK location not found)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69180aefef00832b82f45f712e5cdaa6)