### PR TITLE
Adjust profile sheets for keyboard behavior

### DIFF
--- a/app/src/main/assets/scripts/modules/controls.js
+++ b/app/src/main/assets/scripts/modules/controls.js
@@ -1455,6 +1455,7 @@
       if (!fieldSheet || fieldSheet.dataset.open !== 'true' || !visualViewport) return;
       const bottomOffset = Math.max(0, (window.innerHeight - visualViewport.height - visualViewport.offsetTop));
       fieldSheet.style.setProperty('--keyboard-inset', `${bottomOffset}px`);
+      if (sheet) sheet.style.setProperty('--keyboard-inset', `${bottomOffset}px`);
     };
 
     const attachViewportListeners = () => {
@@ -1469,6 +1470,7 @@
       visualViewport.removeEventListener('resize', updateKeyboardInset);
       visualViewport.removeEventListener('scroll', updateKeyboardInset);
       if (fieldSheet) fieldSheet.style.removeProperty('--keyboard-inset');
+      if (sheet) sheet.style.removeProperty('--keyboard-inset');
     };
 
     const finalizeFieldClose = (focusField = false) => {

--- a/app/src/main/assets/styles/app.css
+++ b/app/src/main/assets/styles/app.css
@@ -559,6 +559,7 @@
     .profile-sheet {
       position: fixed;
       inset: 0;
+      bottom: calc(0px - var(--keyboard-inset, 0px));
       z-index: 60;
       display: flex;
       justify-content: center;


### PR DESCRIPTION
## Summary
- keep the profile editor sheet anchored when the keyboard is shown by offsetting it downward instead of letting it rise with the viewport
- continue lifting the field editor sheet above the keyboard using the existing inset logic
- clean up keyboard inset styles when the field sheet closes

## Testing
- not run (not applicable)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691812e8f858832b88043fb36dcb4377)